### PR TITLE
New Jeopardy - japi

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "npm run build",
     "build": "babel src --out-dir lib --copy-files",
     "start": "node lib/jeopardy",
-    "dev": "nodemon --exec babel-node src/japi",
+    "dev": "nodemon --exec babel-node src/jeopardy",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "npm run build",
     "build": "babel src --out-dir lib --copy-files",
     "start": "node lib/jeopardy",
-    "dev": "nodemon --exec babel-node src/jeopardy",
+    "dev": "nodemon --exec babel-node src/japi",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src"
   },
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",
+    "cheerio": "^0.19.0",
     "eslint": "^1.6.0",
     "eslint-config-xo": "^0.6.0",
     "eslint-plugin-babel": "^2.1.1",

--- a/src/japi.js
+++ b/src/japi.js
@@ -1,0 +1,102 @@
+import fetch from 'node-fetch';
+import striptags from 'striptags';
+import {load} from 'cheerio';
+
+// Hard code number of seasons:
+// Season 32 is relatively incomplete.
+const seasons = 31;
+
+// Selector to get seasons URLS from
+const episodeRegex = /Show #([0-9]+) -/;
+const clueRegex = /clue_J_([0-9]+)_([0-9]+)/;
+
+async function loadEpisode(url) {
+  const res = await fetch(url);
+  const text = await res.text();
+  const $ = load(text);
+
+  // Extract the episode number:
+  const headerText = $('#game_title > *').text();
+  const [, episode] = episodeRegex.exec(headerText);
+
+  // Extract categories:
+  const categories = [];
+  $('#jeopardy_round .category_name').each((id, category) => {
+    // Don't use zero-based index:
+    id += 1;
+    categories.push({
+      id,
+      title: $(category).text()
+    });
+  });
+
+  const clues = [];
+
+  $('#jeopardy_round .clue').each((id, clue) => {
+    // Don't use zero-based index:
+    id += 1;
+
+    const $clue = $(clue);
+    const $clueText = $clue.find('.clue_text');
+
+    let [, category_id, num] = clueRegex.exec($clueText.attr('id'));
+    category_id = parseInt(category_id, 10);
+    num = parseInt(num, 10);
+
+    // Generate the value based on the number:
+    const value = num * 200;
+
+    const question = $clueText.text();
+
+    // Extract the answer and strip HTML tags:
+    let [, answer] = /ponse">(.*)<\/e/.exec($clue.find('td:first-child > div').attr('onmouseover'));
+    answer = striptags(answer);
+
+    // Extract if this question was a daily double:
+    const dailyDouble = $clue.find('.clue_value_daily_double').length === 1;
+
+    clues.push({
+      id,
+      category_id,
+      question,
+      answer,
+      value,
+      dailyDouble
+    });
+  });
+
+  // Return it:
+  return {
+    episode,
+    roundOne: {
+      categories,
+      clues
+    }
+  };
+}
+
+async function loadRandomEpisode() {
+  const season = Math.ceil(Math.random() * seasons);
+  const res = await fetch(`http://www.j-archive.com/showseason.php?season=${season}`);
+  const text = await res.text();
+  const $ = load(text);
+  const links = $('td:first-child > a');
+  const episodeLink = links.eq(Math.ceil(Math.random() * links.length)).attr('href');
+
+  const {episode, roundOne} = await loadEpisode(episodeLink);
+
+  return {
+    season,
+    episode,
+    roundOne
+  };
+}
+
+loadRandomEpisode().then(season => {
+  console.log(season.roundOne, season.episode);
+}).catch(e => {
+  console.log(e.stack);
+});
+
+// Seasons info:
+// http://www.j-archive.com/showseason.php?season=32

--- a/src/japi.js
+++ b/src/japi.js
@@ -75,7 +75,7 @@ async function loadEpisode(url) {
   };
 }
 
-async function loadRandomEpisode() {
+export async function randomEpisode() {
   const season = Math.ceil(Math.random() * seasons);
   const res = await fetch(`http://www.j-archive.com/showseason.php?season=${season}`);
   const text = await res.text();
@@ -91,12 +91,3 @@ async function loadRandomEpisode() {
     roundOne
   };
 }
-
-loadRandomEpisode().then(season => {
-  console.log(season.roundOne, season.episode);
-}).catch(e => {
-  console.log(e.stack);
-});
-
-// Seasons info:
-// http://www.j-archive.com/showseason.php?season=32


### PR DESCRIPTION
This is a pretty big shift in how we gather data.

Instead of going to jService and attempting to build our games, we now actually just model the games after actual jeopardy games, randomly selected and parsed directly from j-archive. This means our data is a little easier to manage and more predictable. We also assign in our own question values now, so that will never be an issue.

This opens the door to things like final jeopardy, media clues (when they exist, and detection for when they don't!), double jeopardy, and daily doubles. I've already added a daily double flag to questions that we could implement in the near future.

There is still an error that occurs sometimes. I'm looking into it, but the failure rate is still far lower than the jService API.

Oh, and this is much faster because there's about 5 less service requests to build a board.
