### PR TITLE
Adding migrations

### DIFF
--- a/migrations/1-slackid-to-id.js
+++ b/migrations/1-slackid-to-id.js
@@ -1,0 +1,15 @@
+module.exports.id = 'slackid-to-id';
+
+module.exports.up = function migrateUp(done) {
+  const contestants = this.db.collection('contestants');
+  contestants.updateMany({}, { $rename: { slackid: 'id' } }, function updateManyComplete(err) {
+    done(err);
+  });
+};
+
+module.exports.down = function migrateDown(done) {
+  const contestants = this.db.collection('contestants');
+  contestants.updateMany({}, { $rename: { id: 'slackid' } }, function updateManyComplete(err) {
+    done(err);
+  });
+};

--- a/migrations/config.js
+++ b/migrations/config.js
@@ -1,0 +1,22 @@
+const url = require('url');
+
+// Stolen from src/config:
+const MONGO = process.env.MONGO_URL || process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://localhost/jeopardy';
+
+const parsedUrl = url.parse(MONGO);
+const auth = {};
+if (parsedUrl.auth) {
+  auth.user = parsedUrl.auth.split(':')[0];
+  auth.password = parsedUrl.auth.split(':')[1];
+}
+
+module.exports = {
+  host: parsedUrl.hostname,
+  port: parsedUrl.port,
+  db: parsedUrl.path.substr(1),
+  user: auth.user,
+  password: auth.password,
+  collection: 'migrations',
+  directory: './migrations',
+  poolSize: 1,
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "private": true,
   "scripts": {
     "postinstall": "npm run build",
+    "migrate": "mm --config='migrations/config.js'",
+    "migrate:create": "mm create -- --config='migrations/config.js'",
     "fonts:linux": "cp ./.fonts/*.ttf /usr/share/fonts/fontfiles && sudo fc-cache -fv",
     "fonts:osx": "cp ./.fonts/*.ttf /Library/Fonts/",
     "build": "babel src --out-dir lib --copy-files && npm run admin",
@@ -41,6 +43,7 @@
     "imgur": "^0.1.6",
     "lockfile": "^1.0.1",
     "moment": "^2.10.6",
+    "mongodb-migrations": "^0.5.0",
     "mongoose": "^4.1.9",
     "natural": "^0.2.1",
     "node-fetch": "^1.3.3",

--- a/src/api.js
+++ b/src/api.js
@@ -24,7 +24,7 @@ export default (adminAuth) => {
     },
   });
   restify.serve(router, Studio, { prefix: '', lowercase: true, idProperty: 'id' });
-  restify.serve(router, Contestant, { prefix: '', lowercase: true, idProperty: 'slackid' });
+  restify.serve(router, Contestant, { prefix: '', lowercase: true, idProperty: 'id' });
 
   // Manual non-model-backed routes:
   router.post('/v1/broadcasts/', (req, res) => {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,3 @@
-import winston from 'winston';
-
 /*
  * BOT CONFIGURATION:
  */

--- a/src/models/Contestant.js
+++ b/src/models/Contestant.js
@@ -2,7 +2,7 @@ import { Schema, model } from 'mongoose';
 
 export const schema = new Schema({
   // Their slack ID:
-  slackid: {
+  id: {
     type: String,
     required: true,
     index: true,
@@ -58,14 +58,14 @@ schema.virtual('nonMentionedName').get(function () {
   return `${this.name.charAt(0)}.${this.name.substring(1)}`;
 });
 
-schema.statics.get = async function({ user_id: slackid, user_name: name }) {
+schema.statics.get = async function({ user_id: id, user_name: name }) {
   let user = await this.findOne({
-    slackid,
+    id,
   });
   if (!user) {
     user = await this.create({
       name,
-      slackid,
+      id,
     });
   } else if (user.name !== name) {
     // Update their slack username because it's changed.

--- a/src/trebek/Command.js
+++ b/src/trebek/Command.js
@@ -188,7 +188,7 @@ export default class Command {
         return !this.game || this.game.isComplete();
       case 'mydailydouble':
         const isDailyDouble = this.game.isDailyDouble();
-        const myDailyDouble = this.game.dailyDouble.contestant === this.contestant.slackid;
+        const myDailyDouble = this.game.dailyDouble.contestant === this.contestant.id;
         const hasWager = !!this.game.dailyDouble.wager;
         return (isDailyDouble && myDailyDouble && !hasWager);
       case 'clue':

--- a/src/trebek/commands/challenge.js
+++ b/src/trebek/commands/challenge.js
@@ -49,10 +49,10 @@ export default class Challenge extends Command {
     if (!challenge && this.game.isChallengeStarted()) {
       const correct = Boolean(yes);
       // Register the vote if we haven't already voted:
-      const hasVoted = this.game.challenge.votes.some(vote => vote.contestant === this.contestant.slackid);
+      const hasVoted = this.game.challenge.votes.some(vote => vote.contestant === this.contestant.id);
       if (!hasVoted) {
         this.game.challenge.votes.push({
-          contestant: this.contestant.slackid,
+          contestant: this.contestant.id,
           correct,
         });
         await this.game.save();
@@ -78,7 +78,7 @@ export default class Challenge extends Command {
         return;
       }
 
-      const contestantString = contestants.map(contestant => `<@${contestant.slackid}>`).join(', ');
+      const contestantString = contestants.map(contestant => `<@${contestant.id}>`).join(', ');
       await this.say(`I'm not sure, let's see what the room thinks.\nI thought the correct answer was \`${answer}\`, and the guess was \`${guess}\`.`);
 
       let messageText = `${contestantString}, do you think they were right?`;

--- a/src/trebek/commands/clue.js
+++ b/src/trebek/commands/clue.js
@@ -101,7 +101,7 @@ class Clue extends Command {
       // Make sure that the daily double image displays before we do anything else:
       await this.say('Answer: Daily Double', dailyDoubleUrl);
       const channelScore = this.contestant.channelScore(this.data.channel_id).value;
-      this.say(`Your score is ${currency(channelScore)}. What would you like to wager, <@${this.contestant.slackid}>? ` +
+      this.say(`Your score is ${currency(channelScore)}. What would you like to wager, <@${this.contestant.id}>? ` +
                `(max of ${currency(Math.max(channelScore, clue.value))}, min of $5)`);
       // TODO: Wager timeouts
     } else {

--- a/src/trebek/commands/stats.js
+++ b/src/trebek/commands/stats.js
@@ -19,7 +19,7 @@ export default class Stats extends Command {
     }
     const score = contestant.channelScore(this.data.channel_id).value;
 
-    this.say(`Stats for *<@${contestant.slackid}>*:
+    this.say(`Stats for *<@${contestant.id}>*:
 > _${currency(score)} current game_ *|* _${currency(contestant.stats.money)} total_ *|* _${contestant.stats.won} wins_ *|* _${contestant.stats.lost} losses_`);
   }
 }


### PR DESCRIPTION
This adds migrations to allow us to seamlessly change the data model. Included is the first migration, the `slackid-to-id` migration. When this lands, I'll be testing it on the main JeopardyBot instance with 100+ contestants. Should be interesting. Fixes #142.

One thing that I still need to figure out is how to make this magic with Heroku's code pulls.

@pstephenson02 you might find this interesting :)
