### PR TITLE
Update config.js to use the proper mLab config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ You can configure the bot by using the admin control panel. You can go to the ad
 
 ### Configuring MongoDB
 
-There are three different environment variables that you can use to set the URL for MongoDB. JeopardyBot will check the environment variables `MONGO_URL`, `MONGOHQ_URL`, and `MONGOLAB_URI` (in that order), before finally defaulting to `mongodb://localhost/jeopardy`.
+There are three different environment variables that you can use to set the URL for MongoDB. JeopardyBot will check the environment variables `MONGO_URL`, `MONGOHQ_URL`, and `MONGODB_URI` (in that order), before finally defaulting to `mongodb://localhost/jeopardy`.

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ export const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'bot';
 export const IMGUR_API = process.env.IMGUR_API || '';
 
 // The URL for the mongo database:
-export const MONGO = process.env.MONGO_URL || process.env.MONGOHQ_URL || process.env.MONGOLAB_URI || 'mongodb://localhost/jeopardy';
+export const MONGO = process.env.MONGO_URL || process.env.MONGOHQ_URL || process.env.MONGODB_URI || 'mongodb://localhost/jeopardy';
 
 // The port for the application:
 export const PORT = process.env.PORT || 8000;


### PR DESCRIPTION
This PR is related to https://github.com/kesne/jeopardy-bot/issues/187. As it turns out, mongoose was not the issue. mLab must have changed its Heroku env variable name to `MONGODB_URI` at some point. Because that key doesn't exist in config.js it was actually trying to connect to localhost.

https://devcenter.heroku.com/articles/mongolab#getting-your-connection-uri
