### PR TITLE
Detect incomplete games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 lib/
 npm-debug.log
+package-lock.json

--- a/src/japi/index.ts
+++ b/src/japi/index.ts
@@ -24,6 +24,11 @@ async function loadEpisode(url: string) {
     const response = await axios.get(url, { responseType: 'text' });
     const $ = load(response.data);
 
+    // Incomplete episode?
+    if ($('#jeopardy_round .clue').length !== $('#jeopardy_round .clue_text').length) {
+      throw new ReferenceError('Incomplete episode!');
+    }
+
     // Extract the episode number:
     const headerText = $('#game_title > *').text();
     const episodeMatches = episodeRegex.exec(headerText) || [];
@@ -141,7 +146,7 @@ export async function generateGame(gameId?: string) {
         try {
             game = await randomEpisode();
         } catch (e) {
-            console.error('Unable to generate game.', game, e);
+            console.error('Unable to generate game.', e);
         }
     } while (!game);
     return game;


### PR DESCRIPTION
The loop code for generating a random game is built to ignore errors and try again, but when the board is incomplete, this code won't know and it only fails during rendering the image when there are one or more clues missing.

I am doing a simple node count and if there are clues missing we error out which will trigger a new random loop.